### PR TITLE
S3 IAM user policy updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,6 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 resource "aws_kms_key" "s3_bucket_kms_key" {
   count = "${var.kms_alias != "" && length(var.whitelist_ip) == 0 ? 1 : 0}"

--- a/policy.tf
+++ b/policy.tf
@@ -10,7 +10,10 @@ data "aws_iam_policy_document" "s3_bucket_with_kms_policy_document_1" {
     ]
 
     actions = [
+      "s3:GetBucketLocation",
       "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListBucketVersions",
     ]
   }
 
@@ -23,9 +26,11 @@ data "aws_iam_policy_document" "s3_bucket_with_kms_policy_document_1" {
     ]
 
     actions = [
-      "s3:PutObject",
-      "s3:GetObject",
+      "s3:AbortMultipartUpload",
       "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
     ]
   }
 }
@@ -88,7 +93,10 @@ data "aws_iam_policy_document" "s3_bucket_policy_document" {
     ]
 
     actions = [
+      "s3:GetBucketLocation",
       "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListBucketVersions",
     ]
   }
 
@@ -101,9 +109,11 @@ data "aws_iam_policy_document" "s3_bucket_policy_document" {
     ]
 
     actions = [
-      "s3:PutObject",
-      "s3:GetObject",
+      "s3:AbortMultipartUpload",
       "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
     ]
   }
 }
@@ -173,7 +183,10 @@ data "aws_iam_policy_document" "s3_bucket_with_kms_policy_document_whitelist_1" 
     ]
 
     actions = [
+      "s3:GetBucketLocation",
       "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListBucketVersions",
     ]
 
     condition {
@@ -192,9 +205,11 @@ data "aws_iam_policy_document" "s3_bucket_with_kms_policy_document_whitelist_1" 
     ]
 
     actions = [
-      "s3:PutObject",
-      "s3:GetObject",
+      "s3:AbortMultipartUpload",
       "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
     ]
 
     condition {
@@ -275,7 +290,10 @@ data "aws_iam_policy_document" "s3_bucket_policy_document_whitelist" {
     ]
 
     actions = [
+      "s3:GetBucketLocation",
       "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListBucketVersions",
     ]
 
     condition {
@@ -294,9 +312,11 @@ data "aws_iam_policy_document" "s3_bucket_policy_document_whitelist" {
     ]
 
     actions = [
-      "s3:PutObject",
-      "s3:GetObject",
+      "s3:AbortMultipartUpload",
       "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
     ]
 
     condition {


### PR DESCRIPTION
- S3 IAM user policy updates
- Remove argument current when retrieving the aws region as it's now deprecated