### PR TITLE
Set a valid default ACL for s3 bucket creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Module usage:
 
 | Name | Description | Default | Required |
 |------|-------------|:-----:|:-----:|
-| acl | The access control list assigned to this bucket | `public` | no |
+| acl | The access control list assigned to this bucket | `private` | no |
 | bucket_iam_user | The name of the iam user assigned to the created s3 bucket | - | yes |
 | environment | The environment the S3 is running in i.e. dev, prod etc | - | yes |
 | iam_user_policy_name | The policy name of attached to the user | - | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "versioning_enabled" {
 
 variable "acl" {
   description = "The access control list assigned to this bucket"
-  default     = "public"
+  default     = "private"
 }
 
 variable "whitelist_ip" {


### PR DESCRIPTION
I'm not sure how `public` ever worked... => https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl