### PR TITLE
Enable lifecycle rules for non-current version objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Module usage:
 | cors\_allowed\_origins | Specifies which origins are allowed. | list | `<list>` | no |
 | cors\_expose\_headers | Specifies expose header in the response. | list | `<list>` | no |
 | cors\_max\_age\_seconds | Specifies time in seconds that browser can cache the response for a preflight request. | string | `"3000"` | no |
+| expire\_noncurrent\_versions | Allow expiration/retention rules to apply for all non-current version objects | string | `"true"` | no |
 | environment | The environment the S3 is running in i.e. dev, prod etc | string | n/a | yes |
 | iam\_user\_policy\_name | The policy name of attached to the user | string | n/a | yes |
 | kms\_alias | The alias name for the kms key used to encrypt and decrypt the created S3 bucket objects | string | `""` | no |
@@ -47,6 +48,7 @@ Module usage:
 | number\_of\_users | The number of user to generate credentials for | string | `"1"` | no |
 | server\_side\_encryption\_configuration | Provides access to override the server side encryption configuration | list | `<list>` | no |
 | tags | A map of tags to add to all resources | map | `<map>` | no |
+| transition\_noncurrent\_versions | Allow lifecycle rules to apply for all non-current version objects | string | `"true"` | no |
 | versioning\_enabled | If versioning is set for buckets in case of accidental deletion | string | `"false"` | no |
 | website\_error\_document | The path to the document to return in case of a 4XX error for static website hosting | string | `"error.html"` | no |
 | website\_hosting | Specifies if the bucket will be used for static website hosting | string | `"false"` | no |

--- a/main.tf
+++ b/main.tf
@@ -167,6 +167,14 @@ resource "aws_s3_bucket" "s3_bucket" {
       days          = var.lifecycle_days_to_infrequent_storage_transition
       storage_class = "STANDARD_IA"
     }
+
+    dynamic "noncurrent_version_transition" {
+      for_each = var.transition_noncurrent_versions == "false" ? [] : [1]
+      content {
+        days          = var.lifecycle_days_to_infrequent_storage_transition
+        storage_class = "STANDARD_IA"
+      }
+    }
   }
 
   lifecycle_rule {
@@ -181,6 +189,14 @@ resource "aws_s3_bucket" "s3_bucket" {
       days          = var.lifecycle_days_to_glacier_transition
       storage_class = "GLACIER"
     }
+
+    dynamic "noncurrent_version_transition" {
+      for_each = var.transition_noncurrent_versions == "false" ? [] : [1]
+      content {
+        days          = var.lifecycle_days_to_glacier_transition
+        storage_class = "GLACIER"
+      }
+    }
   }
 
   lifecycle_rule {
@@ -193,6 +209,13 @@ resource "aws_s3_bucket" "s3_bucket" {
 
     expiration {
       days = var.lifecycle_days_to_expiration
+    }
+
+    dynamic "noncurrent_version_expiration" {
+      for_each = var.expire_noncurrent_versions == "false" ? [] : [1]
+      content {
+        days = var.lifecycle_days_to_expiration
+      }
     }
   }
 
@@ -257,6 +280,14 @@ resource "aws_s3_bucket" "s3_bucket_with_logging" {
       days          = var.lifecycle_days_to_infrequent_storage_transition
       storage_class = "STANDARD_IA"
     }
+
+    dynamic "noncurrent_version_transition" {
+      for_each = var.transition_noncurrent_versions == "false" ? [] : [1]
+      content {
+        days          = var.lifecycle_days_to_infrequent_storage_transition
+        storage_class = "STANDARD_IA"
+      }
+    }
   }
 
   lifecycle_rule {
@@ -271,6 +302,14 @@ resource "aws_s3_bucket" "s3_bucket_with_logging" {
       days          = var.lifecycle_days_to_glacier_transition
       storage_class = "GLACIER"
     }
+
+    dynamic "noncurrent_version_transition" {
+      for_each = var.transition_noncurrent_versions == "false" ? [] : [1]
+      content {
+        days          = var.lifecycle_days_to_glacier_transition
+        storage_class = "GLACIER"
+      }
+    }
   }
 
   lifecycle_rule {
@@ -283,6 +322,13 @@ resource "aws_s3_bucket" "s3_bucket_with_logging" {
 
     expiration {
       days = var.lifecycle_days_to_expiration
+    }
+
+    dynamic "noncurrent_version_expiration" {
+      for_each = var.expire_noncurrent_versions == "false" ? [] : [1]
+      content {
+        days = var.lifecycle_days_to_expiration
+      }
     }
   }
 
@@ -352,6 +398,14 @@ resource "aws_s3_bucket" "s3_website_bucket" {
       days          = var.lifecycle_days_to_infrequent_storage_transition
       storage_class = "STANDARD_IA"
     }
+
+    dynamic "noncurrent_version_transition" {
+      for_each = var.transition_noncurrent_versions == "false" ? [] : [1]
+      content {
+        days          = var.lifecycle_days_to_infrequent_storage_transition
+        storage_class = "STANDARD_IA"
+      }
+    }
   }
 
   lifecycle_rule {
@@ -366,6 +420,14 @@ resource "aws_s3_bucket" "s3_website_bucket" {
       days          = var.lifecycle_days_to_glacier_transition
       storage_class = "GLACIER"
     }
+
+    dynamic "noncurrent_version_transition" {
+      for_each = var.transition_noncurrent_versions == "false" ? [] : [1]
+      content {
+        days          = var.lifecycle_days_to_glacier_transition
+        storage_class = "GLACIER"
+      }
+    }
   }
 
   lifecycle_rule {
@@ -378,6 +440,13 @@ resource "aws_s3_bucket" "s3_website_bucket" {
 
     expiration {
       days = var.lifecycle_days_to_expiration
+    }
+
+    dynamic "noncurrent_version_expiration" {
+      for_each = var.expire_noncurrent_versions == "false" ? [] : [1]
+      content {
+        days = var.lifecycle_days_to_expiration
+      }
     }
   }
 
@@ -447,6 +516,14 @@ resource "aws_s3_bucket" "s3_website_bucket_with_logging" {
       days          = var.lifecycle_days_to_infrequent_storage_transition
       storage_class = "STANDARD_IA"
     }
+
+    dynamic "noncurrent_version_transition" {
+      for_each = var.transition_noncurrent_versions == "false" ? [] : [1]
+      content {
+        days          = var.lifecycle_days_to_infrequent_storage_transition
+        storage_class = "STANDARD_IA"
+      }
+    }
   }
 
   lifecycle_rule {
@@ -461,6 +538,14 @@ resource "aws_s3_bucket" "s3_website_bucket_with_logging" {
       days          = var.lifecycle_days_to_glacier_transition
       storage_class = "GLACIER"
     }
+
+    dynamic "noncurrent_version_transition" {
+      for_each = var.transition_noncurrent_versions == "false" ? [] : [1]
+      content {
+        days          = var.lifecycle_days_to_glacier_transition
+        storage_class = "GLACIER"
+      }
+    }
   }
 
   lifecycle_rule {
@@ -473,6 +558,13 @@ resource "aws_s3_bucket" "s3_website_bucket_with_logging" {
 
     expiration {
       days = var.lifecycle_days_to_expiration
+    }
+
+    dynamic "noncurrent_version_expiration" {
+      for_each = var.expire_noncurrent_versions == "false" ? [] : [1]
+      content {
+        days = var.lifecycle_days_to_expiration
+      }
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,11 @@ variable "cors_max_age_seconds" {
   default     = "3000"
 }
 
+variable "expire_noncurrent_versions" {
+  description = "Allow expiration/retention rules to apply for all non-current version objects"
+  default     = "true"
+}
+
 variable "iam_user_policy_name" {
   description = "The policy name of attached to the user"
 }
@@ -147,6 +152,11 @@ variable "server_side_encryption_configuration" {
 variable "tags" {
   description = "A map of tags to add to all resources"
   default     = {}
+}
+
+variable "transition_noncurrent_versions" {
+  description = "Allow lifecycle rules to apply for all non-current version objects"
+  default     = "true"
 }
 
 variable "versioning_enabled" {


### PR DESCRIPTION
Added the following flags which will apply expiration or transition lifecycles to non-current versions of objects when versioning is enabled on a bucket:
- expire_noncurrent_versions
- transition_noncurrent_versions