### PR TITLE
Change policies to get/put object version tagging

### DIFF
--- a/policy.tf
+++ b/policy.tf
@@ -22,12 +22,14 @@ data "aws_iam_policy_document" "s3_bucket_with_kms_policy_document_1" {
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListBucketVersions",
       "s3:ListMultipartUploadParts",
       "s3:PutObjectAcl",
       "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
       "s3:RestoreObject",
     ]
   }
@@ -110,12 +112,14 @@ data "aws_iam_policy_document" "s3_bucket_policy_document" {
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListBucketVersions",
       "s3:ListMultipartUploadParts",
       "s3:PutObjectAcl",
       "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
       "s3:RestoreObject",
     ]
   }
@@ -212,12 +216,14 @@ data "aws_iam_policy_document" "s3_bucket_with_kms_policy_document_whitelist_1" 
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListBucketVersions",
       "s3:ListMultipartUploadParts",
       "s3:PutObjectAcl",
       "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
       "s3:RestoreObject",
     ]
 
@@ -312,12 +318,14 @@ data "aws_iam_policy_document" "s3_bucket_policy_document_whitelist" {
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListBucketVersions",
       "s3:ListMultipartUploadParts",
       "s3:PutObjectAcl",
       "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
       "s3:RestoreObject",
     ]
 
@@ -432,12 +440,14 @@ data "aws_iam_policy_document" "s3_bucket_with_kms_and_whitelist_vpc_policy_docu
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListBucketVersions",
       "s3:ListMultipartUploadParts",
       "s3:PutObjectAcl",
       "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
       "s3:RestoreObject",
     ]
 
@@ -532,12 +542,14 @@ data "aws_iam_policy_document" "s3_bucket_with_whitelist_vpc_policy_document" {
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListBucketVersions",
       "s3:ListMultipartUploadParts",
       "s3:PutObjectAcl",
       "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
       "s3:RestoreObject",
     ]
 
@@ -652,12 +664,14 @@ data "aws_iam_policy_document" "s3_bucket_with_kms_and_whitelist_ip_and_vpc_poli
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListBucketVersions",
       "s3:ListMultipartUploadParts",
       "s3:PutObjectAcl",
       "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
       "s3:RestoreObject",
     ]
 
@@ -720,12 +734,14 @@ data "aws_iam_policy_document" "s3_bucket_with_kms_and_whitelist_ip_and_vpc_poli
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListBucketVersions",
       "s3:ListMultipartUploadParts",
       "s3:PutObjectAcl",
       "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
       "s3:RestoreObject",
     ]
 
@@ -820,12 +836,14 @@ data "aws_iam_policy_document" "s3_bucket_with_whitelist_ip_and_vpc_policy_docum
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListBucketVersions",
       "s3:ListMultipartUploadParts",
       "s3:PutObjectAcl",
       "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
       "s3:RestoreObject",
     ]
 
@@ -876,12 +894,14 @@ data "aws_iam_policy_document" "s3_bucket_with_whitelist_ip_and_vpc_policy_docum
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListBucketVersions",
       "s3:ListMultipartUploadParts",
       "s3:PutObjectAcl",
       "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
       "s3:RestoreObject",
     ]
 
@@ -1020,6 +1040,7 @@ data "aws_iam_policy_document" "s3_bucket_with_kms_website_policy_document_1" {
       "s3:GetObject",
       "s3:GetObjectAcl",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersionTagging",
       "s3:ListBucket",
       "s3:ListBucketMultipartUploads",
       "s3:ListBucketVersions",
@@ -1027,6 +1048,7 @@ data "aws_iam_policy_document" "s3_bucket_with_kms_website_policy_document_1" {
       "s3:PutObject",
       "s3:PutObjectAcl",
       "s3:PutObjectTagging",
+      "s3:PutObjectVersionTagging",
       "s3:RestoreObject",
     ]
   }


### PR DESCRIPTION
Appending policies to include the following actions:
- s3:GetObjectVersionTagging
- s3:PutObjectVersionTagging